### PR TITLE
spark mllib 2.1 uses breeze 0.12

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   )
 
   object Compile {
-    val breeze_natives = "org.scalanlp" %% "breeze-natives" % "0.11.2" % "provided"
+    val breeze_natives = "org.scalanlp" %% "breeze-natives" % "0.12" % "provided"
 
     object Test {
       val scalatest = "org.scalatest" %% "scalatest" % "2.2.4" % "test"


### PR DESCRIPTION
this can cause the following issue

http://stackoverflow.com/questions/43169853/apache-spark-java-lang-nosuchmethoderror-breeze-linalg-vector-scalaroflbre