### PR TITLE
Convert MLib vector type to ML vector type in MNISTBenchmark for #26

### DIFF
--- a/spark-knn-examples/src/main/scala/com/github/saurfang/spark/ml/knn/examples/MNISTBenchmark.scala
+++ b/spark-knn-examples/src/main/scala/com/github/saurfang/spark/ml/knn/examples/MNISTBenchmark.scala
@@ -32,12 +32,15 @@ object MNISTBenchmark {
     import spark.implicits._
 
     //read in raw label and features
-    val dataset = MLUtils.loadLibSVMFile(sc, path)
+    val rawDataset = MLUtils.loadLibSVMFile(sc, path)
       .zipWithIndex()
       .filter(_._2 < ns.max)
       .sortBy(_._2, numPartitions = numPartitions)
       .keys
       .toDF()
+
+    // convert "features" from mllib.linalg.Vector to ml.linalg.Vector
+    val dataset =  MLUtils.convertVectorColumnsToML(rawDataset)
       .cache()
     dataset.count() //force persist
 


### PR DESCRIPTION
Although MNIST.scala has this change, MNISTBenchmark.scala does not