### PR TITLE
Pyspark2.3 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ cd ..
 sbt package
 
 # need to add jar twice because of https://issues.apache.org/jira/browse/SPARK-5185:
-spark-submit --pyfiles python/dist/pyspark_knn-*.egg --driver-class-path spark-knn-core/target/scala-2.10/spark-knn_*.jar --jars spark-knn-core/target/scala-2.10/spark-knn_*.jar YOUR_SCRIPT
+spark-submit --py-files python/dist/pyspark_knn-*.egg --driver-class-path 
+spark-knn-core/target/scala-2.10/spark-knn_*.jar --jars spark-knn-core/target/scala-2.10/spark-knn_*.jar YOUR_SCRIPT
 ```
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ python setup.py bdist_egg
 cd ..
 sbt package
 
-# need to add jar twice because of https://issues.apache.org/jira/browse/SPARK-5185:
-spark-submit --py-files python/dist/pyspark_knn-*.egg --driver-class-path 
-spark-knn-core/target/scala-2.10/spark-knn_*.jar --jars spark-knn-core/target/scala-2.10/spark-knn_*.jar YOUR_SCRIPT
+spark-submit --py-files python/dist/pyspark_knn-*.egg --driver-class-path spark-knn-core/target/scala-2.10/spark-knn_*.jar --jars spark-knn-core/target/scala-2.10/spark-knn_*.jar YOUR_SCRIPT
 ```
 
 ## Benchmark

--- a/python/pyspark_knn/ml/classification.py
+++ b/python/pyspark_knn/ml/classification.py
@@ -1,7 +1,7 @@
 from pyspark.ml.wrapper import JavaEstimator, JavaModel
 from pyspark.ml.param.shared import *
 from pyspark.mllib.common import inherit_doc
-from pyspark.ml.util import keyword_only
+from pyspark import keyword_only
 
 
 @inherit_doc
@@ -38,7 +38,7 @@ class KNNClassifier(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol
                          bufferSizeSampleSize=list(range(100, 1000 + 1, 100)), balanceThreshold=0.7,
                          k=5, neighborsCol="neighbors", maxNeighbors=float("inf"))
 
-        kwargs = self.__init__._input_kwargs
+        kwargs = self._input_kwargs
         self.setParams(**kwargs)
 
     @keyword_only
@@ -47,7 +47,7 @@ class KNNClassifier(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol
                   bufferSizeSampleSize=list(range(100, 1000 + 1, 100)), balanceThreshold=0.7,
                   k=5, neighborsCol="neighbors", maxNeighbors=float("inf"), rawPredictionCol="rawPrediction",
                   probabilityCol="probability"):
-        kwargs = self.setParams._input_kwargs
+        kwargs = self._input_kwargs
         return self._set(**kwargs)
 
     def _create_model(self, java_model):

--- a/python/pyspark_knn/ml/regression.py
+++ b/python/pyspark_knn/ml/regression.py
@@ -1,7 +1,7 @@
 from pyspark.ml.wrapper import JavaEstimator, JavaModel
 from pyspark.ml.param.shared import *
 from pyspark.mllib.common import inherit_doc
-from pyspark.ml.util import keyword_only
+from pyspark import keyword_only
 
 
 @inherit_doc
@@ -36,7 +36,7 @@ class KNNRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol
                          bufferSizeSampleSize=list(range(100, 1000 + 1, 100)), balanceThreshold=0.7,
                          k=5, neighborsCol="neighbors", maxNeighbors=float("inf"))
 
-        kwargs = self.__init__._input_kwargs
+        kwargs = self._input_kwargs
         self.setParams(**kwargs)
 
     @keyword_only
@@ -44,7 +44,7 @@ class KNNRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol
                   seed=None, topTreeSize=1000, topTreeLeafSize=10, subTreeLeafSize=30, bufferSize=-1.0,
                   bufferSizeSampleSize=list(range(100, 1000 + 1, 100)), balanceThreshold=0.7,
                   k=5, neighborsCol="neighbors", maxNeighbors=float("inf")):
-        kwargs = self.setParams._input_kwargs
+        kwargs = self._input_kwargs
         return self._set(**kwargs)
 
     def _create_model(self, java_model):


### PR DESCRIPTION
I've updated the Python example to be compatible with the latest version of pyspark (2.3) as well as fixing a typo in the readme section for python.