### PR TITLE
Add support for nan-euclidean distance measure

### DIFF
--- a/spark-knn-core/src/main/scala/org/apache/spark/ml/knn/DistanceMetric.scala
+++ b/spark-knn-core/src/main/scala/org/apache/spark/ml/knn/DistanceMetric.scala
@@ -1,0 +1,94 @@
+package org.apache.spark.ml.knn
+
+import org.apache.spark.ml.knn.KNN.VectorWithNorm
+import org.apache.spark.mllib.knn.KNNUtils
+
+
+object DistanceMetric {
+  def apply(metric: String): DistanceMetric = {
+    metric match {
+      case "" | "euclidean" => EuclideanDistanceMetric
+      case "nan_euclidean" => NaNEuclideanDistanceMetric
+      case _ => throw new IllegalArgumentException(s"Unsupported distance metric: $metric")
+    }
+  }
+}
+trait DistanceMetric {
+  def fastSquaredDistance(v1: VectorWithNorm, v2: VectorWithNorm): Double
+
+  def fastDistance(v1: VectorWithNorm, v2: VectorWithNorm): Double = {
+    math.sqrt(fastSquaredDistance(v1, v2))
+  }
+}
+
+object EuclideanDistanceMetric extends DistanceMetric with Serializable {
+  override def fastSquaredDistance(v1: VectorWithNorm, v2: VectorWithNorm): Double = {
+    KNNUtils.fastSquaredDistance(v1.vector, v1.norm, v2.vector, v2.norm)
+  }
+}
+
+/**
+ * Calculate NaN-Euclidean distance by using only non NaN values in each vector
+ */
+object NaNEuclideanDistanceMetric extends DistanceMetric with Serializable {
+
+  class InfiniteZeroIterator(step: Int = 1) extends Iterator[(Int, Double)] {
+    var index = -1 * step
+    override def hasNext: Boolean = true
+    override def next(): (Int, Double) = {
+      index += step
+      (index, 0.0)
+    }
+  }
+  override def fastSquaredDistance(v1: VectorWithNorm, v2: VectorWithNorm): Double = {
+    var it1 = v1.vector.activeIterator
+    var it2 = v2.vector.activeIterator
+    if(!it1.hasNext && !it2.hasNext) return 0.0
+    if(!it1.hasNext) {
+      it1 = new InfiniteZeroIterator
+    } else if(!it2.hasNext) {
+      it2 = new InfiniteZeroIterator
+    }
+    var result = 0.0
+    // initial case
+    var (idx1, val1) = it1.next()
+    var (idx2, val2) = it2.next()
+    // iterator over the vectors
+    while((it1.hasNext || it2.hasNext) && !(it1.isInstanceOf[InfiniteZeroIterator] && it2.isInstanceOf[InfiniteZeroIterator])) {
+      var (advance1, advance2) = (false, false)
+      val (left, right) = if(idx1 < idx2) {
+        // advance iterator on first vector
+        advance1 = true
+        (val1, 0.0)
+      } else if(idx1 > idx2) {
+        // advance iterator on second vector
+        advance2 = true
+        (0.0, val2)
+      } else {
+        // indexes matches
+        advance1 = true
+        advance2 = true
+        (val1, val2)
+      }
+      if(!left.isNaN && !right.isNaN) {
+        result += Math.pow(left - right, 2)
+      }
+      if(advance1) {
+        if(!it1.hasNext) it1 = new InfiniteZeroIterator
+        val next1 = it1.next()
+        idx1 = next1._1
+        val1 = next1._2
+      }
+      if(advance2) {
+        if(!it2.hasNext) it2 = new InfiniteZeroIterator
+        val next2 = it2.next()
+        idx2 = next2._1
+        val2 = next2._2
+      }
+    }
+    if(idx1 == idx2 && !val1.isNaN && !val2.isNaN) {
+      result += Math.pow(val1 - val2, 2)
+    }
+    result
+  }
+}

--- a/spark-knn-core/src/main/scala/org/apache/spark/ml/knn/KNN.scala
+++ b/spark-knn-core/src/main/scala/org/apache/spark/ml/knn/KNN.scala
@@ -101,6 +101,9 @@ private[ml] trait KNNModelParams extends Params with HasFeaturesCol with HasInpu
   /** @group getParam */
   def getMetric: String = $(metric)
 
+  //fill in default distance metric
+  setDefault(metric, "euclidean")
+
   private[ml] def transform(data: RDD[Vector], topTree: Broadcast[Tree], subTrees: RDD[Tree]): RDD[(Long, Array[(Row,Double)])] = {
     val searchData = data.zipWithIndex()
       .flatMap {
@@ -406,7 +409,8 @@ class KNN(override val uid: String) extends Estimator[KNNModel] with KNNParams {
 
     val tau =
       if ($(balanceThreshold) > 0 && $(bufferSize) < 0) {
-        KNN.estimateTau(data, $(bufferSizeSampleSizes), rand.nextLong(), distanceMetric)
+        val estimates = KNN.estimateTau(data, $(bufferSizeSampleSizes), rand.nextLong(), distanceMetric)
+        math.max(0, estimates)
       } else {
         math.max(0, $(bufferSize))
       }

--- a/spark-knn-core/src/main/scala/org/apache/spark/ml/knn/KNN.scala
+++ b/spark-knn-core/src/main/scala/org/apache/spark/ml/knn/KNN.scala
@@ -456,7 +456,7 @@ object KNN {
     }
   }
 
-  object EuclideanDistanceMetric extends DistanceMetric {
+  object EuclideanDistanceMetric extends DistanceMetric with Serializable {
     override def fastSquaredDistance(v1: VectorWithNorm, v2: VectorWithNorm): Double = {
       KNNUtils.fastSquaredDistance(v1.vector, v1.norm, v2.vector, v2.norm)
     }
@@ -465,7 +465,7 @@ object KNN {
   /**
    * Calculate NaN-Euclidean distance by using only non NaN values in each vector
    */
-  object NaNEuclideanDistanceMetric extends DistanceMetric {
+  object NaNEuclideanDistanceMetric extends DistanceMetric with Serializable {
 
     override def fastSquaredDistance(v1: VectorWithNorm, v2: VectorWithNorm): Double = {
       val it1 = v1.vector.activeIterator

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/DistanceMetricSpec.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/DistanceMetricSpec.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.ml.knn
 
-import org.apache.spark.ml.knn.KNN.{EuclideanDistanceMetric, NaNEuclideanDistanceMetric, RowWithVector, VectorWithNorm}
+import org.apache.spark.ml.knn.KNN.{RowWithVector, VectorWithNorm}
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -44,6 +44,39 @@ class DistanceMetricSpec extends AnyFunSpec with Matchers {
       }
       it("should return distance for two vectors") {
         distanceMetric.fastDistance(v1, v2) shouldBe Math.sqrt(8.0)
+      }
+    }
+    describe("calculate distance between two sparse vectors with invalid values") {
+      val v1 = new VectorWithNorm(Vectors.sparse(5, Seq((1, 1.0), (2, Double.NaN), (3, Double.NaN), (4, 1.0))))
+      val v2 = new VectorWithNorm(Vectors.sparse(5, Seq((0, -1.0), (1, Double.NaN), (4, -1.0))))
+
+      it("should return distance for vector and self") {
+        distanceMetric.fastDistance(v1, v1) shouldBe 0.0
+      }
+      it("should return distance for two vectors") {
+        distanceMetric.fastDistance(v1, v2) shouldBe Math.sqrt(5.0)
+      }
+    }
+    describe("calculate distance between a sparse vectors and all 0 vector") {
+      val v1 = new VectorWithNorm(Vectors.sparse(5, Seq((0, 0.0), (1, 0.0), (3, 0.0), (4, 0.0))))
+      val v2 = new VectorWithNorm(Vectors.sparse(5, Seq((0, -1.0), (1, Double.NaN), (4, -1.0))))
+
+      it("should return distance for vector and self") {
+        distanceMetric.fastDistance(v1, v1) shouldBe 0.0
+      }
+      it("should return distance for two vectors") {
+        distanceMetric.fastDistance(v1, v2) shouldBe Math.sqrt(2.0)
+      }
+    }
+    describe("calculate distance between a sparse vectors and empty vector") {
+      val v1 = new VectorWithNorm(Vectors.sparse(5, Seq()))
+      val v2 = new VectorWithNorm(Vectors.sparse(5, Seq((0, -1.0), (1, Double.NaN), (4, -1.0))))
+
+      it("should return distance for vector and self") {
+        distanceMetric.fastDistance(v1, v1) shouldBe 0.0
+      }
+      it("should return distance for two vectors") {
+        distanceMetric.fastDistance(v1, v2) shouldBe Math.sqrt(2.0)
       }
     }
   }

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/DistanceMetricSpec.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/DistanceMetricSpec.scala
@@ -1,0 +1,50 @@
+package org.apache.spark.ml.knn
+
+import org.apache.spark.ml.knn.KNN.{EuclideanDistanceMetric, NaNEuclideanDistanceMetric, RowWithVector, VectorWithNorm}
+import org.apache.spark.ml.linalg.Vectors
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class DistanceMetricSpec extends AnyFunSpec with Matchers {
+
+  describe("EuclideanDistanceMetric") {
+    val distanceMetric = EuclideanDistanceMetric
+    describe("calculate distance between two dense vectors") {
+      val v1 = new VectorWithNorm(Vectors.dense(1, 1))
+      val v2 = new VectorWithNorm(Vectors.dense(-1, -1))
+
+      it("should return distance for vector and self") {
+        distanceMetric.fastDistance(v1, v1) shouldBe 0.0
+      }
+      it("should return distance for two vectors") {
+        distanceMetric.fastDistance(v1, v2) shouldBe Math.sqrt(8.0)
+      }
+    }
+  }
+
+  describe("NaNEuclideanDistanceMetric") {
+    val distanceMetric = NaNEuclideanDistanceMetric
+    describe("calculate distance between two dense vectors with valid values") {
+      val v1 = new VectorWithNorm(Vectors.dense(1, 1))
+      val v2 = new VectorWithNorm(Vectors.dense(-1, -1))
+
+      it("should return distance for vector and self") {
+        distanceMetric.fastDistance(v1, v1) shouldBe 0.0
+      }
+      it("should return distance for two vectors") {
+        distanceMetric.fastDistance(v1, v2) shouldBe Math.sqrt(8.0)
+      }
+    }
+    describe("calculate distance between two dense vectors with invalid values") {
+      val v1 = new VectorWithNorm(Vectors.dense(1, 1, Double.NaN, Double.NaN, 1))
+      val v2 = new VectorWithNorm(Vectors.dense(-1, Double.NaN, -1, -1, -1))
+
+      it("should return distance for vector and self") {
+        distanceMetric.fastDistance(v1, v1) shouldBe 0.0
+      }
+      it("should return distance for two vectors") {
+        distanceMetric.fastDistance(v1, v2) shouldBe Math.sqrt(8.0)
+      }
+    }
+  }
+}

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/KNNSuite.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/KNNSuite.scala
@@ -3,7 +3,7 @@ package org.apache.spark.ml.knn
 import org.apache.spark.ml.PredictionModel
 import org.apache.spark.ml.classification.KNNClassifier
 import org.apache.spark.ml.feature.VectorAssembler
-import org.apache.spark.ml.knn.KNN.{EuclideanDistanceMetric, VectorWithNorm}
+import org.apache.spark.ml.knn.KNN.VectorWithNorm
 import org.apache.spark.ml.regression.KNNRegression
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.sql.functions._

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/MetricTreeSpec.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/MetricTreeSpec.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.ml.knn
 
-import org.apache.spark.ml.knn.KNN.{EuclideanDistanceMetric, RowWithVector, VectorWithNorm}
+import org.apache.spark.ml.knn.KNN.{RowWithVector, VectorWithNorm}
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/MetricTreeSpec.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/MetricTreeSpec.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.ml.knn
 
-import org.apache.spark.ml.knn.KNN.{RowWithVector, VectorWithNorm}
+import org.apache.spark.ml.knn.KNN.{EuclideanDistanceMetric, RowWithVector, VectorWithNorm}
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -8,14 +8,15 @@ import org.scalatest.matchers.should.Matchers
 class MetricTreeSpec extends AnyFunSpec with Matchers {
 
   describe("MetricTree") {
+    val distanceMetric = EuclideanDistanceMetric
     val origin = Vectors.dense(0, 0)
     describe("can be constructed with empty data") {
-      val tree = MetricTree.build(IndexedSeq.empty[RowWithVector])
+      val tree = MetricTree.build(IndexedSeq.empty[RowWithVector], distanceMetric=distanceMetric)
       it("iterator should be empty") {
         tree.iterator shouldBe empty
       }
       it("should return empty when queried") {
-        tree.query(origin) shouldBe empty
+        tree.query(origin).isEmpty shouldBe true
       }
       it("should have zero leaf") {
         tree.leafCount shouldBe 0
@@ -27,7 +28,7 @@ class MetricTreeSpec extends AnyFunSpec with Matchers {
       List(1, data.size / 2, data.size, data.size * 2).foreach {
         leafSize =>
           describe(s"with leafSize of $leafSize") {
-            val tree = MetricTree.build(data, leafSize)
+            val tree = MetricTree.build(data, leafSize, distanceMetric=distanceMetric)
             it("should have correct size") {
               tree.size shouldBe data.size
             }
@@ -53,7 +54,7 @@ class MetricTreeSpec extends AnyFunSpec with Matchers {
             }
             it("all points should fall with radius of pivot") {
               def check(tree: Tree): Unit = {
-                tree.iterator.foreach(_.vector.fastDistance(tree.pivot) <= tree.radius)
+                tree.iterator.foreach(node=> distanceMetric.fastDistance(node.vector, tree.pivot) <= tree.radius)
                 tree match {
                   case t: MetricTree =>
                     check(t.leftChild)
@@ -69,7 +70,7 @@ class MetricTreeSpec extends AnyFunSpec with Matchers {
 
     describe("with duplicates") {
       val data = (Vectors.dense(2.0, 0.0) +: Array.fill(5)(Vectors.dense(0.0, 1.0))).map(new RowWithVector(_, null))
-      val tree = MetricTree.build(data)
+      val tree = MetricTree.build(data, distanceMetric=distanceMetric)
       it("should have 2 leaves") {
         tree.leafCount shouldBe 2
       }
@@ -82,8 +83,8 @@ class MetricTreeSpec extends AnyFunSpec with Matchers {
 
     describe("for other corner cases") {
       it("queryCost should work on Empty") {
-        Empty.distance(new KNNCandidates(new VectorWithNorm(origin), 1)) shouldBe 0
-        Empty.distance(new VectorWithNorm(origin)) shouldBe 0
+        Empty(distanceMetric).distance(new KNNCandidates(new VectorWithNorm(origin), 1, distanceMetric)) shouldBe 0
+        Empty(distanceMetric).distance(new VectorWithNorm(origin)) shouldBe 0
       }
     }
   }

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/SpillTreeSpec.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/SpillTreeSpec.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.ml.knn
 
-import org.apache.spark.ml.knn.KNN.{EuclideanDistanceMetric, RowWithVector}
+import org.apache.spark.ml.knn.KNN.RowWithVector
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/SpillTreeSpec.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/SpillTreeSpec.scala
@@ -1,20 +1,21 @@
 package org.apache.spark.ml.knn
 
-import org.apache.spark.ml.knn.KNN.RowWithVector
+import org.apache.spark.ml.knn.KNN.{EuclideanDistanceMetric, RowWithVector}
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 class SpillTreeSpec extends AnyFunSpec with Matchers {
   describe("SpillTree") {
+    val distanceMetric = EuclideanDistanceMetric
     val origin = Vectors.dense(0, 0)
     describe("can be constructed with empty data") {
-      val tree = SpillTree.build(IndexedSeq.empty[RowWithVector], tau = 0.0)
+      val tree = SpillTree.build(IndexedSeq.empty[RowWithVector], tau = 0.0, distanceMetric=distanceMetric)
       it("iterator should be empty") {
         tree.iterator shouldBe empty
       }
       it("should return empty when queried") {
-        tree.query(origin) shouldBe empty
+        tree.query(origin).isEmpty shouldBe true
       }
       it("should have zero leaf") {
         tree.leafCount shouldBe 0
@@ -28,7 +29,7 @@ class SpillTreeSpec extends AnyFunSpec with Matchers {
       }
       val leafSize = n / 4
       describe("built with tau = 0.0") {
-        val tree = SpillTree.build(points, leafSize = leafSize, tau = 0.0)
+        val tree = SpillTree.build(points, leafSize = leafSize, tau = 0.0, distanceMetric=distanceMetric)
         it("should have correct size") {
           tree.size shouldBe points.size
         }
@@ -41,7 +42,7 @@ class SpillTreeSpec extends AnyFunSpec with Matchers {
         }
       }
       describe("built with tau = 0.5") {
-        val tree = SpillTree.build(points, leafSize = leafSize, tau = 0.5)
+        val tree = SpillTree.build(points, leafSize = leafSize, tau = 0.5, distanceMetric=distanceMetric)
         it("should have correct size") {
           tree.size shouldBe points.size
         }
@@ -71,12 +72,12 @@ class SpillTreeSpec extends AnyFunSpec with Matchers {
   describe("HybridTree") {
     val origin = Vectors.dense(0, 0)
     describe("can be constructed with empty data") {
-      val tree = HybridTree.build(IndexedSeq.empty[RowWithVector], tau = 0.0)
+      val tree = HybridTree.build(IndexedSeq.empty[RowWithVector], tau = 0.0, distanceMetric=EuclideanDistanceMetric)
       it("iterator should be empty") {
         tree.iterator shouldBe empty
       }
       it("should return empty when queried") {
-        tree.query(origin) shouldBe empty
+        tree.query(origin).isEmpty shouldBe true
       }
       it("should have zero leaf") {
         tree.leafCount shouldBe 0
@@ -89,7 +90,7 @@ class SpillTreeSpec extends AnyFunSpec with Matchers {
         i => new RowWithVector(Vectors.dense(math.sin(2 * math.Pi * i / n), math.cos(2 * math.Pi * i / n)), null)
       }
       val leafSize = n / 4
-      val tree = HybridTree.build(points, leafSize = leafSize, tau = 0.5)
+      val tree = HybridTree.build(points, leafSize = leafSize, tau = 0.5, distanceMetric=EuclideanDistanceMetric)
       it("should have correct size") {
         tree.size shouldBe points.size
       }

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/regression/KNNRegressionSuite.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/regression/KNNRegressionSuite.scala
@@ -1,0 +1,63 @@
+package org.apache.spark.ml.regression
+
+import org.apache.spark.ml.feature.VectorAssembler
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class KNNRegressionSuite extends AnyFunSuite with Matchers {
+
+  val spark = SparkSession.builder()
+    .master("local")
+    .getOrCreate()
+
+  import spark.implicits._
+  val rawDF1 = Seq(
+    (9.5,37.48596719,-122.2428196, 1.0),
+    (9.5,37.49115273,-122.2319523, 2.0),
+    (9.5,37.49099652,-122.2324551, 3.0),
+    (9.5,37.4886712,-122.2348786, 1.0),
+    (9.5,37.48696518,-122.2384678, 3.0),
+    (9.5,37.48473396,-122.2345444, 3.0),
+    (9.5,37.48565758,-122.2412995, 2.0),
+    (9.5,37.48033504,-122.2364642, 2.0)
+  ).toDF("col1", "col2", "col3", "label")
+  val rawDF2 = Seq(
+    (9.5,37.48495049,-122.2335112)
+  ).toDF("col1", "col2", "col3")
+
+  val assembler = new VectorAssembler()
+    .setInputCols(Array("col1", "col2", "col3"))
+    .setOutputCol("features")
+  val trainDF = assembler.transform(rawDF1)
+  val testDF = assembler.transform(rawDF2)
+
+  test("KNNRegression can be fitted using euclidean distance") {
+    val knnr = new KNNRegression()
+      .setTopTreeSize(5)
+      .setFeaturesCol("features")
+      .setPredictionCol("prediction")
+      .setLabelCol("label")
+      .setSeed(31)
+      .setK(5)
+    val knnModel = knnr.fit(trainDF)
+    val outputDF = knnModel.transform(testDF)
+    val predictions = outputDF.collect().map(_.getAs[Double]("prediction"))
+    predictions shouldEqual Array(2.4)
+  }
+
+  test("KNNRegression can be fitted using nan_euclidean distance") {
+    val knnr = new KNNRegression()
+      .setTopTreeSize(5)
+      .setFeaturesCol("features")
+      .setPredictionCol("prediction")
+      .setLabelCol("label")
+      .setSeed(31)
+      .setK(5)
+    knnr.set(knnr.metric, "nan_euclidean")
+    val knnModel = knnr.fit(trainDF)
+    val outputDF = knnModel.transform(testDF)
+    val predictions = outputDF.collect().map(_.getAs[Double]("prediction"))
+    predictions shouldEqual Array(2.4)
+  }
+}

--- a/spark-knn-examples/src/main/scala/org/apache/spark/ml/classification/NaiveKNN.scala
+++ b/spark-knn-examples/src/main/scala/org/apache/spark/ml/classification/NaiveKNN.scala
@@ -1,7 +1,7 @@
 package org.apache.spark.ml.classification
 
 import org.apache.spark.SparkException
-import org.apache.spark.ml.knn.KNN.{RowWithVector, VectorWithNorm}
+import org.apache.spark.ml.knn.KNN.{DistanceMetric, EuclideanDistanceMetric, RowWithVector, VectorWithNorm}
 import org.apache.spark.ml.knn.{KNNModel, KNNParams}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
@@ -19,8 +19,9 @@ import scala.collection.mutable.ArrayBuffer
 /**
   * Brute-force kNN with k = 1
   */
-class NaiveKNNClassifier(override val uid: String) extends Predictor[Vector, NaiveKNNClassifier, NaiveKNNClassifierModel] {
-  def this() = this(Identifiable.randomUID("naiveknnc"))
+class NaiveKNNClassifier(override val uid: String, val distanceMetric: DistanceMetric)
+  extends Predictor[Vector, NaiveKNNClassifier, NaiveKNNClassifierModel] {
+  def this() = this(Identifiable.randomUID("naiveknnc"), EuclideanDistanceMetric)
 
   override def copy(extra: ParamMap): NaiveKNNClassifier = defaultCopy(extra)
 
@@ -57,7 +58,7 @@ class NaiveKNNClassifier(override val uid: String) extends Predictor[Vector, Nai
       case (label, features) => (label, new VectorWithNorm(features))
     }
 
-    new NaiveKNNClassifierModel(uid, points, numClasses)
+    new NaiveKNNClassifierModel(uid, points, numClasses, distanceMetric)
   }
 
 }
@@ -65,7 +66,8 @@ class NaiveKNNClassifier(override val uid: String) extends Predictor[Vector, Nai
 class NaiveKNNClassifierModel(
                                override val uid: String,
                                val points: RDD[(Double, VectorWithNorm)],
-                               val _numClasses: Int) extends ProbabilisticClassificationModel[Vector, NaiveKNNClassifierModel] {
+                               val _numClasses: Int,
+                               val distanceMetric: DistanceMetric) extends ProbabilisticClassificationModel[Vector, NaiveKNNClassifierModel] {
   override def numClasses: Int = _numClasses
 
   override def transform(dataset: Dataset[_]): DataFrame = {
@@ -78,7 +80,7 @@ class NaiveKNNClassifierModel(
       .cartesian(points)
       .map {
         case ((u, i), (label, v)) =>
-            val dist = u.fastSquaredDistance(v)
+            val dist = distanceMetric.fastSquaredDistance(u, v)
             (i, (dist, label))
       }
       .topByKey(1)(Ordering.by(e => -e._1))
@@ -133,7 +135,7 @@ class NaiveKNNClassifierModel(
   }
 
   override def copy(extra: ParamMap): NaiveKNNClassifierModel = {
-    val copied = new NaiveKNNClassifierModel(uid, points, numClasses)
+    val copied = new NaiveKNNClassifierModel(uid, points, numClasses, distanceMetric)
     copyValues(copied, extra).setParent(parent)
   }
 

--- a/spark-knn-examples/src/main/scala/org/apache/spark/ml/classification/NaiveKNN.scala
+++ b/spark-knn-examples/src/main/scala/org/apache/spark/ml/classification/NaiveKNN.scala
@@ -1,8 +1,8 @@
 package org.apache.spark.ml.classification
 
 import org.apache.spark.SparkException
-import org.apache.spark.ml.knn.KNN.{DistanceMetric, EuclideanDistanceMetric, RowWithVector, VectorWithNorm}
-import org.apache.spark.ml.knn.{KNNModel, KNNParams}
+import org.apache.spark.ml.knn.KNN.{RowWithVector, VectorWithNorm}
+import org.apache.spark.ml.knn.{DistanceMetric, EuclideanDistanceMetric, KNNModel, KNNParams}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
 import org.apache.spark.ml.{Model, Predictor}


### PR DESCRIPTION
Add support for the nan-euclidean distance measure as available in sklearn's [KNNImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.KNNImputer.html)

Changes:
- Added new param `metric` for specifying the distance measure metric
- Extracted the logic that calculates distance between `VectorWithNorm` into a trait
- Added `EuclideanDistanceMetric` as default measure
- Added `NaNEuclideanDistanceMetric` as the implementation for the nan-euclidean distance measure