### PR TITLE
Add check that data size is greater than topTreeSize

### DIFF
--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/KNNSuite.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/KNNSuite.scala
@@ -167,7 +167,7 @@ class KNNSuite extends AnyFunSuite with Matchers  {
     checkKNN(knn.setWeightCol("z").fit)
   }
 
-  test("KNNParmas are copied correctly") {
+  test("KNNParams are copied correctly") {
     val knn = new KNNClassifier()
       .setTopTreeSize(data.size / 10)
       .setTopTreeLeafSize(leafSize)
@@ -178,6 +178,19 @@ class KNNSuite extends AnyFunSuite with Matchers  {
     model.getK shouldBe 2
     // check auto generated buffer size is correctly transferred
     model.getBufferSize should be > 0.0
+  }
+
+  test("Errors with helpful message if size of data is smaller than topTreeSize") {
+    val knn = new KNNClassifier()
+      .setTopTreeSize(data.size + 1)
+      .setK(2)
+
+    val thrown = intercept[Exception] {
+      knn.fit(createDataFrame().withColumn("label", lit(1.0)))
+    }
+
+    assert(thrown.getMessage == "Invalid top tree size relative to size of data. " +
+      "Data to fit of size 441 was less than topTreeSize 442")
   }
 
   test("BufferSize is not estimated if rho = 0") {

--- a/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/KNNSuite.scala
+++ b/spark-knn-core/src/test/scala/org/apache/spark/ml/knn/KNNSuite.scala
@@ -180,19 +180,6 @@ class KNNSuite extends AnyFunSuite with Matchers  {
     model.getBufferSize should be > 0.0
   }
 
-  test("Errors with helpful message if size of data is smaller than topTreeSize") {
-    val knn = new KNNClassifier()
-      .setTopTreeSize(data.size + 1)
-      .setK(2)
-
-    val thrown = intercept[Exception] {
-      knn.fit(createDataFrame().withColumn("label", lit(1.0)))
-    }
-
-    assert(thrown.getMessage == "Invalid top tree size relative to size of data. " +
-      "Data to fit of size 441 was less than topTreeSize 442")
-  }
-
   test("BufferSize is not estimated if rho = 0") {
     val knn = new KNNClassifier()
       .setTopTreeSize(data.size / 10)


### PR DESCRIPTION
CL:

- Add check that `topTreeSize` parameter is greater than the input data size. Throws an exceptions stating this.

Motivation behind the change was on this raised issue: https://github.com/saurfang/spark-knn/issues/21 about difficulty debug.

Before this change, the error would be:

```
requirement failed: Sampling fraction (1.002267573696145) must be on interval [0, 1]
java.lang.IllegalArgumentException: requirement failed: Sampling fraction (1.002267573696145) must be on interval [0, 1]
```

whereas now the happens earlier before doing any data transformations, and says:

```
org.apache.spark.SparkException: Invalid top tree size relative to size of data. Data to fit of size 441 was less than topTreeSize 442
```

In a previous commit, included a test for this which matched the string in the error message, but didn't see it as necessary.
